### PR TITLE
ADR: Store ADRs in /adr folder

### DIFF
--- a/adr/ADR-0002-store-adrs-in-adr-folder.md
+++ b/adr/ADR-0002-store-adrs-in-adr-folder.md
@@ -1,0 +1,46 @@
+## Store ADRs in `/adr`/ folder of the repository
+
+_**Authors:** Denis Blanari (Solution Architect)  
+
+_**Status:** Proposed  
+
+_s*_*Set date:: 2025-09-18  
+
+### Context
+ We previously agreed to store ADRs as Markdown files in the repository. However, there is ambiguity about whether they should reside in `/docs/adr`/ or directly under `/adr`/`. A real clarifcation is needed for consistency.  
+
+### Drivers
+
+- **ASSUMPTION:** Keep ADRs in a dedicated folder that is independent of other documentation.  
+- **ASSUMPTION:** Follow community conventions where `/adr`  is the default location.  
+- **ASSUMPTION:*ª Ensure ADRs are easily discoverable at the root of the repo.  
+
+### Options
+
+1. ** Store ADRs under `/docs/adr/`
+
+    - Pros: ADIs grouped with other documentation.  
+    - Cons: Less standard, nested deeper in repo, may be overlooked.  
+
+2. ** Store ADRs under `/adr`/`
+
+    - Pros: Industry standard, dedicated and easily discoverable location.  
+    - Cons: Adds another top-level folder.  
+
+### Decision  
+ADRs will be stored as Markdown files under the `/adr` folder at the root of the repository.  
+
+### Consequences  
+
+Positive:  
+- ADIs are clearly separated from general documentation.  
+- Follows well-established ADJ conventions.  
+- Easier automation and tooling integration.  
+
+Negative:  
+- Adds another root-level directory to the project.  
+- May require migration if existing ADRs were previously placed in `/docs/adr`/`.  
+
+### References  
+- [ADR GitHub community practices](https://adr.github.io/madr/)  
+- Previous ADI PR #1: *Store ADIs in GitHub*  


### PR DESCRIPTION
## Summary
This ADR defines that ADRs will be stored in the `/adr` folder of the repository.

### Drivers
- Ensure ADRs are in a dedicated folder, separate from general documentation.
- Follow community convention where `/adr` is the standard.
- Improve discoverability and automation support.

### Options Considered
1. Store ADRs under `/docs/adr/`
2. Store ADRs under `/adr/`

### Decision
We will store ADRs under the `/adr` folder at the root of the repository.

### Consequences
**Positive:**
- Clear separation from general documentation.
- Aligns with established ADR practices.
- Easier tooling integration.

**Negative:**
- Adds an additional top-level folder.
- May require migration of any existing ADRs.

### References
- [ADR GitHub community practices](https://adr.github.io/madr/)
- Previous ADR PR #1: Store ADRs in GitHub

---

Status: Proposed

Author: Denis Blanari (Solution Architect)